### PR TITLE
Skip if there is no selector

### DIFF
--- a/app/assets/javascripts/rails_admin/bootstrap/bootstrap-tab.js
+++ b/app/assets/javascripts/rails_admin/bootstrap/bootstrap-tab.js
@@ -46,7 +46,7 @@
     $previous.trigger(hideEvent)
     $this.trigger(showEvent)
 
-    if (showEvent.isDefaultPrevented() || hideEvent.isDefaultPrevented()) return
+    if (selector == '#' || showEvent.isDefaultPrevented() || hideEvent.isDefaultPrevented()) return
 
     var $target = $(document).find(selector)
 


### PR DESCRIPTION
Jquery $(document).find(selector) failing for selector = '#'